### PR TITLE
Changed migrations.go to use the use_zero flag

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -38,7 +38,7 @@ type lock struct {
 	tableName struct{} `sql:"migration_lock,alias:migration_lock"`
 
 	ID       string
-	IsLocked bool `sql:",notnull"`
+	IsLocked bool `pg:",use_zero" sql:",notnull"`
 }
 
 const lockID = "lock"


### PR DESCRIPTION
This change prevents go-pg from changing zero values to NULL resulting in trying to use DEFAULT on not null columns even when there is no default set.

Fixes #14

Additional information available on the GO-PG commit
https://github.com/go-pg/pg/commit/48d7259c1a81de5769d0375c4eb7e4172d147123#diff-4ac32a78649ca5bdd8e0ba38b7006a1e